### PR TITLE
Add config option for custom indentation character

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rainbow_documentation
 A documentation for RSpec that keeps things colourful
 
-Simply add it to your Gemfile using 
+Simply add it to your Gemfile using
 
 ```ruby
 gem 'rainbow_documentation'
@@ -21,5 +21,16 @@ or in your spec_helper.rb file
 RSpec.configure do |config|
   config.color = true
   config.formatter = 'RainbowDocumentation'
+end
+```
+
+## Custom indentation character
+
+Additionally, you can specify a custom indentation character in your spec_helper.rb (the default is two spaces (`'  '`)).
+```ruby
+RSpec.configure do |config|
+  config.color = true
+  config.formatter = 'RainbowDocumentation'
+  config.indentation_character = '/ '
 end
 ```

--- a/lib/rainbow_documentation.rb
+++ b/lib/rainbow_documentation.rb
@@ -10,6 +10,10 @@ class RainbowDocumentation < RSpec::Core::Formatters::BaseTextFormatter
                                    :example_pending,
                                    :example_failed
 
+  RSpec.configure do |config|
+    config.add_setting :indentation_character, default: '  '
+  end
+
   COLOR = [
     35, #:magenta
     95, #:light_magenta
@@ -73,7 +77,7 @@ class RainbowDocumentation < RSpec::Core::Formatters::BaseTextFormatter
   end
 
   def current_indentation
-    (' ' * 2) * @group_level
+    RSpec.configuration.indentation_character * @group_level
   end
 
   def wrap(text, code)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 RSpec.configure do |config|
   config.color = true
   config.formatter = 'RainbowDocumentation'
+  config.indentation_character = '/ '
 end


### PR DESCRIPTION
Added the `indentation_character` option to RSpec config. It defaults to `'  '` (two spaces). (Issue #5)

<img width="477" alt="screen shot 2016-10-06 at 9 19 41 pm" src="https://cloud.githubusercontent.com/assets/2459843/19176106/ac08cb4c-8c0a-11e6-9ac0-513a9b25ed0a.png">
